### PR TITLE
always use a CachingPool with robust_pmap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Parallelism"
 uuid = "c8c83da1-e5f9-4e2c-a857-b8617bac3554"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/Parallelism.jl
+++ b/src/Parallelism.jl
@@ -1,7 +1,7 @@
 module Parallelism
 
 using Base.Threads
-using Distributed: ProcessExitedException, pmap
+using Distributed
 using LinearAlgebra
 using Memento
 

--- a/src/robust_pmap.jl
+++ b/src/robust_pmap.jl
@@ -24,7 +24,7 @@ function robust_pmap(f::Function, args...; num_retries::Int=3)
         return should_retry
     end
 
-    return pmap(f, args...;
+    return pmap(f, CachingPool(workers()), args...;
         retry_check=retry_check,
         retry_delays=ExponentialBackOff(n=num_retries)
     )


### PR DESCRIPTION
I am of the opinion that `pmap` should do so by default also. (https://github.com/JuliaLang/julia/pull/33892/)
But this stops closures reserializing for every item.
Which if the closure is large could be big.
The overhead of using the `CachingPool` is not large so I don't think there is a downside.
The cache will garbage collect everywhere once this goes out of scope