### PR TITLE
fix tests on 1.8

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/test/robust_pmap.jl
+++ b/test/robust_pmap.jl
@@ -16,11 +16,11 @@
     end
 
     # Check other errors don't retry
-    throw_isodd = make_throw_isodd(ErrorException("Error"))
+    throw_isodd = make_throw_isodd(ErrorException("Error123"))
     if VERSION < v"1.8-"
         @test_throws ErrorException robust_pmap(throw_isodd, input)
     else
-        @test_throws "Error" robust_pmap(throw_isodd, input)
+        @test_throws "Error123" robust_pmap(throw_isodd, input)
     end
 
     # Check ProcessExitedException is retried

--- a/test/robust_pmap.jl
+++ b/test/robust_pmap.jl
@@ -17,7 +17,11 @@
 
     # Check other errors don't retry
     throw_isodd = make_throw_isodd(ErrorException("Error"))
-    @test_throws ErrorException robust_pmap(throw_isodd, input)
+    if VERSION < v"1.8-"
+        @test_throws ErrorException robust_pmap(throw_isodd, input)
+    else
+        @test_throws "Error" robust_pmap(throw_isodd, input)
+    end
 
     # Check ProcessExitedException is retried
     throw_isodd = make_throw_isodd(ProcessExitedException())
@@ -27,8 +31,12 @@
     @test_log LOGGER "info" ("Retrying", "ProcessExitedException") robust_pmap(throw_isodd, input)
     # Check with lower number of retrys
     throw_isodd = make_throw_isodd(ProcessExitedException())
-    @test_throws ProcessExitedException robust_pmap(throw_isodd, input, num_retries=1)
+    if VERSION < v"1.8-"
+        @test_throws ProcessExitedException robust_pmap(throw_isodd, input, num_retries=1)
 
+    else
+        @test_throws "ProcessExitedException" robust_pmap(throw_isodd, input, num_retries=1)
+    end
     # ArgumentErrors with this message should be retried
     throw_isodd = make_throw_isodd(ArgumentError("stream is closed or unusable"))
     @test robust_pmap(throw_isodd, input) == expected
@@ -37,11 +45,19 @@
     @test_log LOGGER "info" ("Retrying", "ArgumentError") robust_pmap(throw_isodd, input)
     # Check with lower number of retrys
     throw_isodd = make_throw_isodd(ArgumentError("stream is closed or unusable"))
-    @test_throws ArgumentError robust_pmap(throw_isodd, input, num_retries=1)
+    if VERSION < v"1.8-"
+        @test_throws ArgumentError robust_pmap(throw_isodd, input, num_retries=1)
+    else
+        @test_throws "stream is closed or unusable" robust_pmap(throw_isodd, input, num_retries=1)
+    end
 
     # Other ArgumentErrors should not be retried
     throw_isodd = make_throw_isodd(ArgumentError("stream is open but other stuff is wrong"))
-    @test_throws ArgumentError robust_pmap(throw_isodd, input)
+    if VERSION < v"1.8-"
+        @test_throws ArgumentError robust_pmap(throw_isodd, input)
+    else
+        @test_throws "stream is open but other stuff is wrong" robust_pmap(throw_isodd, input)
+    end
     # No retries should mean no log of retries
     throw_isodd = make_throw_isodd(ArgumentError("stream is open but other stuff is wrong"))
     @test_nolog LOGGER "info" "Retrying" try robust_pmap(throw_isodd, input) catch end
@@ -54,5 +70,9 @@
     @test_log LOGGER "info" ("Retrying", "IOError") robust_pmap(throw_isodd, input)
     # Check with lower number of retrys
     throw_isodd = make_throw_isodd(Base.IOError("msg", 1))
-    @test_throws Base.IOError robust_pmap(throw_isodd, input, num_retries=1)
+    if VERSION < v"1.8-"
+        @test_throws Base.IOError robust_pmap(throw_isodd, input, num_retries=1)
+    else
+        @test_throws "msg" robust_pmap(throw_isodd, input, num_retries=1)
+    end
 end

--- a/test/robust_pmap.jl
+++ b/test/robust_pmap.jl
@@ -10,7 +10,7 @@
                 i += 1
                 throw(err)
             end
-            isodd(x)
+            return isodd(x)
         end
         return throw_isodd
     end
@@ -28,7 +28,9 @@
     @test robust_pmap(throw_isodd, input) == expected
     # Check retries are logged
     throw_isodd = make_throw_isodd(ProcessExitedException())
-    @test_log LOGGER "info" ("Retrying", "ProcessExitedException") robust_pmap(throw_isodd, input)
+    @test_log LOGGER "info" ("Retrying", "ProcessExitedException") robust_pmap(
+        throw_isodd, input
+    )
     # Check with lower number of retrys
     throw_isodd = make_throw_isodd(ProcessExitedException())
     if VERSION < v"1.8-"
@@ -48,7 +50,9 @@
     if VERSION < v"1.8-"
         @test_throws ArgumentError robust_pmap(throw_isodd, input, num_retries=1)
     else
-        @test_throws "stream is closed or unusable" robust_pmap(throw_isodd, input, num_retries=1)
+        @test_throws "stream is closed or unusable" robust_pmap(
+            throw_isodd, input, num_retries=1
+        )
     end
 
     # Other ArgumentErrors should not be retried
@@ -56,11 +60,16 @@
     if VERSION < v"1.8-"
         @test_throws ArgumentError robust_pmap(throw_isodd, input)
     else
-        @test_throws "stream is open but other stuff is wrong" robust_pmap(throw_isodd, input)
+        @test_throws "stream is open but other stuff is wrong" robust_pmap(
+            throw_isodd, input
+        )
     end
     # No retries should mean no log of retries
     throw_isodd = make_throw_isodd(ArgumentError("stream is open but other stuff is wrong"))
-    @test_nolog LOGGER "info" "Retrying" try robust_pmap(throw_isodd, input) catch end
+    @test_nolog LOGGER "info" "Retrying" try
+        robust_pmap(throw_isodd, input)
+    catch
+    end
 
     # Check IOError is retried
     throw_isodd = make_throw_isodd(Base.IOError("msg", 1))


### PR DESCRIPTION
In 1.8, `asyncmap` throws CapturedExceptions so the stacktrace doesn't get dropped (https://github.com/JuliaLang/julia/pull/42105). This doesn't break pmap retries (because they get unwrapped) but it does change the exception getting thrown, so it breaks the tests here.

This PR uses the feature from https://github.com/JuliaLang/julia/pull/41888 to test against the error text on 1.8 (since the exception type is just CapturedException).